### PR TITLE
Fix Snyk vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # stacks-dotnet-packages-cosmosdb
 
 A collection of common helpful cosmos database classes
+
+
+# How to test locally
+
+To run the tests you will need the [CosmosDB emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator) installed.
+
+* Start the CosmosDB emulator
+* Open the [CosmosDB emulator data explorer](https://localhost:8081/_explorer/index.html) and copy the `Primary Key` value
+* Set the `COSMOSDB_KEY` environment variable with the value of the `Primary Key`
+* In the `src/` folder run `dotnet test`

--- a/build/azDevOps/packages-amido-stacks-data-documents-cosmosdb.yml
+++ b/build/azDevOps/packages-amido-stacks-data-documents-cosmosdb.yml
@@ -210,6 +210,7 @@ stages:
           CosmosDb__DatabaseAccountUri: $[ dependencies.AppInfraDeploy.outputs['tfoutputs.cosmosdb_endpoint'] ]
           COSMOSDB_KEY: $[ dependencies.AppInfraDeploy.outputs['tfoutputs.cosmosdb_primary_master_key'] ]
         steps:
+          - bash: env | sort
           - template: azDevOps/azure/templates/v2/steps/build-dotnet-package.yml@templates
             parameters:
               # Build Config

--- a/build/azDevOps/packages-amido-stacks-data-documents-cosmosdb.yml
+++ b/build/azDevOps/packages-amido-stacks-data-documents-cosmosdb.yml
@@ -210,7 +210,6 @@ stages:
           CosmosDb__DatabaseAccountUri: $[ dependencies.AppInfraDeploy.outputs['tfoutputs.cosmosdb_endpoint'] ]
           COSMOSDB_KEY: $[ dependencies.AppInfraDeploy.outputs['tfoutputs.cosmosdb_primary_master_key'] ]
         steps:
-          - bash: env | sort
           - template: azDevOps/azure/templates/v2/steps/build-dotnet-package.yml@templates
             parameters:
               # Build Config

--- a/deploy/azure/app/kube/outputs.tf
+++ b/deploy/azure/app/kube/outputs.tf
@@ -13,3 +13,8 @@ output "cosmosdb_primary_master_key" {
   sensitive   = true
   value       = module.cosmosdb.cosmosdb_primary_master_key
 }
+
+output "cosmosdb_database_name" {
+  description = "Database name"
+  value       = module.cosmosdb.cosmosdb_database_name
+}

--- a/src/Amido.Stacks.Data.Documents.CosmosDB.Tests/Amido.Stacks.Data.Documents.CosmosDB.Tests.csproj
+++ b/src/Amido.Stacks.Data.Documents.CosmosDB.Tests/Amido.Stacks.Data.Documents.CosmosDB.Tests.csproj
@@ -1,18 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Testing" Version="0.2.18" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
@@ -22,6 +20,7 @@
     <!-- Explicit package references to reduce security vulnerabilities in transitive dependencies identified by Snyk -->
     <PackageReference Include="System.Net.Http" Version="4.3.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.*" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amido.Stacks.Data.Documents.CosmosDB.Tests/Amido.Stacks.Data.Documents.CosmosDB.Tests.csproj
+++ b/src/Amido.Stacks.Data.Documents.CosmosDB.Tests/Amido.Stacks.Data.Documents.CosmosDB.Tests.csproj
@@ -18,6 +18,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+
+    <!-- Explicit package references to reduce security vulnerabilities in transitive dependencies identified by Snyk -->
+    <PackageReference Include="System.Net.Http" Version="4.3.*" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amido.Stacks.Data.Documents.CosmosDB/Amido.Stacks.Data.Documents.CosmosDB.csproj
+++ b/src/Amido.Stacks.Data.Documents.CosmosDB/Amido.Stacks.Data.Documents.CosmosDB.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.18" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.18" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+
+    <!-- Explicit package references to reduce security vulnerabilities in transitive dependencies identified by Snyk -->
+    <PackageReference Include="System.Net.Http" Version="4.3.*" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.*" />
   </ItemGroup>
 
 </Project>

--- a/src/Amido.Stacks.Data.Documents.CosmosDB/Amido.Stacks.Data.Documents.CosmosDB.csproj
+++ b/src/Amido.Stacks.Data.Documents.CosmosDB/Amido.Stacks.Data.Documents.CosmosDB.csproj
@@ -13,12 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Core" Version="0.2.17" />
     <PackageReference Include="Amido.Stacks.Data.Documents.Abstractions" Version="0.2.13" />
-    <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.15" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.18" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.18" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
 
     <!-- Explicit package references to reduce security vulnerabilities in transitive dependencies identified by Snyk -->
     <PackageReference Include="System.Net.Http" Version="4.3.*" />


### PR DESCRIPTION
#### 📲 What

* Update various package references
* Fix missing terraform output `cosmosdb_database_name` - this was being set to an empty value which caused pipeline failures when upgrading the `Microsoft.Azure.Cosmos` package
* Remove `net472` from the target framework for the test project as this is not supported

#### 🤔 Why

To reduce vulnerabilities

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
